### PR TITLE
General clean-up and copyright update

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Todo.txt: Future-proof task tracking in a file you control</title>
 
 	<meta name="description" content="Track your tasks and projects in a plain text file, todo.txt.  A todo.txt is software and operating system agnostic; it's searchable, portable, lightweight and easily manipulated." />
@@ -33,7 +33,7 @@
 	<link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css" />
 	<link rel="stylesheet" type="text/css" href="/css/bootstrap-responsive.css" />
 	<link rel="stylesheet" type="text/css" href="/css/style.css" />
-	<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,600,700" rel="stylesheet" type="text/css" />
+	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700" rel="stylesheet" type="text/css" />
 </head>
 
 <body id="body">
@@ -49,12 +49,12 @@
 				</div>
 				<span class="hidden-phone">
 				<div class="span3">
-					<a href="http://itunes.apple.com/us/app/todo.txt-touch/id491342186?ls=1&mt=8" title="Download on the App Store">
+					<a href="https://itunes.apple.com/us/app/todo.txt-touch/id491342186?ls=1&mt=8" title="Download on the App Store">
 					  <img alt="Download on App Store" src="images/download-on-app-store.png" style="float:right"/>
 					</a>
 				</div>
 				<div class="span2">
-					<a href="http://play.google.com/store/apps/details?id=com.todotxt.todotxttouch" title="Get it on Google Play">
+					<a href="https://play.google.com/store/apps/details?id=com.todotxt.todotxttouch" title="Get it on Google Play">
 					  <img alt="Android app on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge-border.png" width="203" />
 					</a>
 				</div>
@@ -86,31 +86,31 @@
 					<h2>On Your Phone and Tablet</h2>
 					<span class="hidden-phone"><p><img src="images/mobileappsheader.png" alt="Todo.txt mobile apps" /></p></span>
 					<p>Your todo.txt file isn't useful if it's not always at your fingertips. The Todo.txt mobile apps make it easy to view and update your tasks on the go.</p>
-					<p>Currently connected to <a href="http://dropbox.com">Dropbox</a>, Todo.txt Touch helps you manage your todo.txt on your touchscreen mobile device and automatically syncs your changes to all your computers.</p>
+					<p>Currently connected to <a href="https://www.dropbox.com">Dropbox</a>, Todo.txt Touch helps you manage your todo.txt on your touchscreen mobile device and automatically syncs your changes to all your computers.</p>
 					<h4>iPhone, iPod touch, and iPad users:</h4>
 					<p>
-						<a href="http://itunes.apple.com/us/app/todo.txt-touch/id491342186?ls=1&mt=8" title="Download on the App Store">
+						<a href="https://itunes.apple.com/us/app/todo.txt-touch/id491342186?ls=1&mt=8" title="Download on the App Store">
 						  <img alt="Download on App Store" src="images/download-on-app-store.png" />
 						</a>
 					</p>
 					<h4>Android users:</h4>
 					<p>
-					<a href="http://play.google.com/store/apps/details?id=com.todotxt.todotxttouch" title="Get it on Google Play">
+					<a href="https://play.google.com/store/apps/details?id=com.todotxt.todotxttouch" title="Get it on Google Play">
 					  <img alt="Android app on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png" width="203" />
 					</a>
 					</p>
-					<p>Also available in <a href="http://www.amazon.com/o/ASIN/B004MNQTVU/ref=nosim/lifehackerboo-20">the Amazon Appstore</a>.
+					<p>Also available in <a href="https://www.amazon.com/o/ASIN/B004MNQTVU/ref=nosim/lifehackerboo-20">the Amazon Appstore</a>.
 				</div>
 				<div class="span4">
 					<h2>At the Command Line</h2>
 					<p>With a simple but powerful shell script called todo.sh, you can interact with todo.txt at the command line for quick and easy, Unix-y access.</p>
-					<p><span class="hidden-phone"><iframe src="http://player.vimeo.com/video/3263629?byline=0&amp;portrait=0" width="100%" height="320" frameborder="0" webkitAllowFullScreen allowFullScreen></iframe></span></p>
+					<p><span class="hidden-phone"><iframe src="https://player.vimeo.com/video/3263629?byline=0&amp;portrait=0" width="100%" height="320" frameborder="0" webkitAllowFullScreen allowFullScreen></iframe></span></p>
 					<p>The Todo.txt CLI supports archiving completed tasks to done.txt and priority/context tab autocompletion.</p><br>
-					<p><a href="http://github.com/todotxt/todo.txt-cli/releases" class="btn-large btn-success" title="Download Todo.txt CLI">Download Todo.txt CLI &raquo;</a></p><br>
+					<p><a href="https://github.com/todotxt/todo.txt-cli/releases" class="btn-large btn-success" title="Download Todo.txt CLI">Download Todo.txt CLI &raquo;</a></p><br>
 					<p>Find out more:</p>
 					<p><ul>
-						<li><a href="http://wiki.github.com/todotxt/todo.txt-cli">Documentation</a>—everything you need to know about how to use Todo.txt CLI</li>
-						<li><a href="http://groups.yahoo.com/group/todotxt/">Mailing List</a>—ask the Todo.txt community</li>
+						<li><a href="https://wiki.github.com/todotxt/todo.txt-cli">Documentation</a>—everything you need to know about how to use Todo.txt CLI</li>
+						<li><a href="https://groups.yahoo.com/group/todotxt/">Mailing List</a>—ask the Todo.txt community</li>
 					</ul>
 					</p>
 				</div>
@@ -152,17 +152,17 @@
 			<div class="row">
 				<div class="span3">
 					<h3>Desktop</h3>
-					<h4><a href="http://benrhughes.com/todotxt.net/">Todotxt.net</a></h4>
+					<h4><a href="https://benrhughes.com/todotxt.net/">Todotxt.net</a></h4>
 					<p>A minimalist, keyboard-driven Windows GUI for your todo.txt file, by <a href="http://benrhughes.com/">Ben Hughes</a>.</p>
 					<h4><a href="https://chrome.google.com/webstore/detail/ohjgbfjncbnecbnijmpgjhodnhbhnjgk">Todo.txt Chrome App</a></h4>
-					<p>Standalone, offline-ready Chrome app for your todo.txt file - works across Windows, Mac, Linux and Chrome OS, by <a href="http://c306.net/">Aditya Bhaskar<a>.</p>
+					<p>Standalone, offline-ready Chrome app for your todo.txt file - works across Windows, Mac, Linux and Chrome OS, by <a href="https://c306.net/">Aditya Bhaskar<a>.</p>
 					<h4><a href="https://mjdescy.github.io/TodoTxtMac/">TodoTxtMac</a></h4>
 					<p>TodoTxtMac is a minimalist, keyboard-driven to-do manager for Mac OS X (10.8 Mountain Lion and higher), by <a href="https://github.com/mjdescy">mjdescy<a>.</p>
-					<h4><a href="http://nerdur.com/todour.html">Todour</a></h4>
+					<h4><a href="http://nerdur.com/todour-pl/">Todour</a></h4>
 					<p>Todour is an application for handling todo.txt files on the Mac and Windows, by Sverrir Valgeirsson.</p>
 					<h4><a href="https://launchpad.net/~ximilian/+archive/ppa">DoStuff</a></h4>
-					<p>"A todo.txt client for humans" on Ubuntu (<a href="http://2buntu.com/1197/review-dostuff-a-todotxt-client-for-humans/">screenshots and video clip</a>), by ximilian.</p>
-					<h4><a href="http://burnsoftware.wordpress.com/daytasks/">DayTasks</a></h4>
+					<p>"A todo.txt client for humans" on Ubuntu, by ximilian.</p>
+					<h4><a href="https://burnsoftware.wordpress.com/daytasks/">DayTasks</a></h4>
 					<p>A fast, simple, and efficient todo.txt-compatible task list for Ubuntu, by Zach Burnham.</p>
 					<h4><a href="https://github.com/mNantern/QTodoTxt">QTodoTxt</a></h4>
 					<p>A fast, cross-platform todo.txt GUI written in Python, by Matthieu Nantern.</p>
@@ -173,8 +173,8 @@
 				</div>
 				<div class="span3">
 					<h3>Web</h3>
-					<h4><a href="http://todotxttdi.com">Todotxttdi.com</a></h4>
-					<p>HTML5 Dropbox app with text-driven user interface (<a href="https://github.com/DavidPratten/todotxttdi">source</a>), by <a href="http://davidpratten.com">David Pratten</a>.</p>
+					<h4><a href="https://todotxttdi.com">Todotxttdi.com</a></h4>
+					<p>HTML5 Dropbox app with text-driven user interface (<a href="https://github.com/DavidPratten/todotxttdi">source</a>), by <a href="https://davidpratten.com">David Pratten</a>.</p>
 					<h4><a href="http://todo.martinsgill.co.uk">TodoTxtJs</a></h4>
 					<p>Interactive HTML5 todo.txt app with optional Dropbox integration (<a href="https://github.com/MartinSGill/TodoTxtJs">source</a>), by Martin Gill.</p>
 					<h4><a href="https://github.com/bicarbon8/todoTxtWebUi">todoTxtWebUi</a></h4>
@@ -184,7 +184,7 @@
 					<h4><a href="https://github.com/trestletech/Todo.txt">Todo.txt++</a></h4>
 					<p>A sleek, hosted, mobile-friendly web app with Dropbox synchronization, filtering, and searching. You can use it <a href ="https://www.todotxtpp.com">here</a></p>
 					<h4><a href="https://chrome.google.com/webstore/detail/mndijfcodpjlhgjcpcbhncjakaboedbl">Todo.txt Chrome Extension</a></h4>
-					<p>Chrome browser extension to manage your todo.txt file by <a href="http://c306.net/">Aditya Bhaskar<a>.</p>
+					<p>Chrome browser extension to manage your todo.txt file by <a href="https://c306.net/">Aditya Bhaskar<a>.</p>
 				</div>
 				<div class="span3">
 					<h3>Plugins and Add-ons</h3>
@@ -203,12 +203,10 @@
 				</div>
 				<div class="span3">
 					<h3>Mobile</h3>
-					<h4><a href="http://www.windowsphone.com/en-US/apps/50b1ca07-7e23-4963-a0ba-1536e6913543">Todo.txt for Windows Phone 7</a></h4>
-					<p>Todo.txt for Windows Phone 7 is a task manager based on the todo.txt file format, by <a href="https://github.com/hartez">E.Z. Hart</a>.</p>
-					<h4><a href="http://monkeystew.org/apps/">Todo.txt Enyo</a></h4>
+					<h4><a href="https://monkeystew.org/apps/">Todo.txt Enyo</a></h4>
 					<p>A webOS application for managing your todo.txt file written using the EnyoJS framework, by <a href="https://github.com/thrrgilag">thrrgilag</a>.</p>
 					<h4><a href="https://play.google.com/store/apps/details?id=nl.mpcjanssen.todotxtholo">Simpletask</a></h4>
-					<p>Powerful todo.txt app for Android, by <a href="http://mpcjanssen.nl/">Mark Janssen</a>. Also available in a <a href="https://play.google.com/store/apps/details?id=nl.mpcjanssen.simpletask">cloudless</a> version.</p>
+					<p>Powerful todo.txt app for Android, by <a href="https://mpcjanssen.nl/">Mark Janssen</a>. Also available in a <a href="https://play.google.com/store/apps/details?id=nl.mpcjanssen.simpletask">cloudless</a> version.</p>
 					<h3>Developer Tools</h3>
 					<h4><a href="https://github.com/samwho/todo-txt-gem">Todo.txt Gem</a></h4>
 					<p>A RubyGem for parsing todo.txt files, by <a href="https://github.com/samwho">Sam Rose</a>.</p>
@@ -228,11 +226,11 @@
 		<div class="fill">
 			<div class="container">
 				<div class="row">
-					<p>Unless otherwise noted, Todo.txt apps published herein are authored by <a href="http://ginatrapani.org/" title="Gina Trapani:  The Official Site">Gina Trapani</a> in collaboration with <a href="https://github.com/todotxt/todo.txt-cli/contributors">Todo.txt</a> <a href="https://github.com/todotxt/todo.txt-touch-ios/contributors">community</a> <a href="https://github.com/todotxt/todo.txt-touch/contributors">members</a> and released under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License</a>.</p>
-					<p>Todo.txt's icon designed by <a href="http://twitter.com/eJohnR">John Rowley</a>.</p>
-					<p>The first version of the Todo.txt CLI script was originally <a href="http://lifehacker.com/software/top/geek-to-live--readerwritten-todotxt-manager-173018.php">published in 2006 on Lifehacker</a>.</p>
+					<p>Unless otherwise noted, Todo.txt apps published herein are authored by <a href="https://ginatrapani.org/" title="Gina Trapani:  The Official Site">Gina Trapani</a> in collaboration with <a href="https://github.com/todotxt/todo.txt-cli/contributors">Todo.txt</a> <a href="https://github.com/todotxt/todo.txt-touch-ios/contributors">community</a> <a href="https://github.com/todotxt/todo.txt-touch/contributors">members</a> and released under the <a href="https://www.gnu.org/copyleft/gpl.html">GNU General Public License</a>.</p>
+					<p>Todo.txt's icon designed by <a href="https://twitter.com/eJohnR">John Rowley</a>.</p>
+					<p>The first version of the Todo.txt CLI script was originally <a href="https://lifehacker.com/software/top/geek-to-live--readerwritten-todotxt-manager-173018.php">published in 2006 on Lifehacker</a>.</p>
 
-					<p>All software comes as is with no warranty.  Do back up your todo.txt before you read another word.  Support is available on the <a href="http://groups.yahoo.com/group/todotxt/">Todo.txt community mailing list</a>.</p>
+					<p>All software comes as is with no warranty.  Do back up your todo.txt before you read another word.  Support is available on the <a href="https://groups.yahoo.com/group/todotxt/">Todo.txt community mailing list</a>.</p>
 					</p>
 				</div>
 			</div>
@@ -242,16 +240,12 @@
 		<div class="fill">
 			<div class="container">
 				<div class="row">
-					<p>Copyright &copy; 2006-2017, <a href="http://ginatrapani.org/" title="Gina Trapani">Gina Trapani</a>.<a style="visibility:hidden" href="https://plus.google.com/113612142759476883204?rel=author">Gina Trapani</a></p>
+					<p>Copyright &copy; 2006-2017, <a href="https://ginatrapani.org/" title="Gina Trapani">Gina Trapani</a>.<a style="visibility:hidden" href="https://plus.google.com/113612142759476883204?rel=author">Gina Trapani</a></p>
 				</div>
 			</div>
 		</div>
 	</div>
-	<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-	</script>
-	<script type="text/javascript">
-		_uacct = "UA-436966-1";
-		urchinTracker();
-	</script>
+	<script src="https://www.google-analytics.com/urchin.js"></script> 
+	<script> _uacct = "UA-436966-1"; urchinTracker(); </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
 		<div class="fill">
 			<div class="container">
 				<div class="row">
-					<p>Copyright &copy; 2006-2016, <a href="http://ginatrapani.org/" title="Gina Trapani">Gina Trapani</a>.<a style="visibility:hidden;" href="https://plus.google.com/113612142759476883204?rel=author">Gina Trapani</a></p>
+					<p>Copyright &copy; 2006-2017, <a href="http://ginatrapani.org/" title="Gina Trapani">Gina Trapani</a>.<a style="visibility:hidden;" href="https://plus.google.com/113612142759476883204?rel=author">Gina Trapani</a></p>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -198,6 +198,8 @@
 					<p>by <a href="https://github.com/dertuxmalwieder">Cthulhux</a></p>
 					<h4><a href="https://addons.mozilla.org/en-US/thunderbird/addon/todotxt-extension/">Todo.txt Thunderbird Extension</a></h4>
 					<p>by <a href="https://github.com/rkokkelk/todo.txt-ext">Roy Kokkelkoren</a></p>
+					<h4><a href="https://atom.io/packages/language-todotxt">Atom plugin for todo.txt</a></h4>
+					<p>A plugin to make editing your todo.txt in Atom a breeze.</p>
 				</div>
 				<div class="span3">
 					<h3>Mobile</h3>

--- a/index.html
+++ b/index.html
@@ -240,16 +240,16 @@
 		<div class="fill">
 			<div class="container">
 				<div class="row">
-					<p>Copyright &copy; 2006-2017, <a href="http://ginatrapani.org/" title="Gina Trapani">Gina Trapani</a>.<a style="visibility:hidden;" href="https://plus.google.com/113612142759476883204?rel=author">Gina Trapani</a></p>
+					<p>Copyright &copy; 2006-2017, <a href="http://ginatrapani.org/" title="Gina Trapani">Gina Trapani</a>.<a style="visibility:hidden" href="https://plus.google.com/113612142759476883204?rel=author">Gina Trapani</a></p>
 				</div>
 			</div>
 		</div>
 	</div>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-	_uacct = "UA-436966-1";
-	urchinTracker();
-</script>
+	<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
+	</script>
+	<script type="text/javascript">
+		_uacct = "UA-436966-1";
+		urchinTracker();
+	</script>
 </body>
 </html>


### PR DESCRIPTION
In this pull request:

- Changed sites that support SSL from `http` to `https` (avoids leakage when the browser requests the URL without SSL first)
- Added the Atom plugin (Fixes #10)
- Removed a link that no longer works (I didn't check them all; there are probably more out there)
- Updated the copyright to 2017
- Generic code fixes

I love the idea of todo.txt and am willing to contribute to it. I'd love to help with issue #1 as well as other projects relating to todo.txt.