### PR TITLE
Fix link to todo.txt format

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
 				<div class="span4">
 					<h2>In Any Text Editor</h2>
 					<p>Countless productivity apps and sites store your tasks in their own proprietary database and file format. But you can work with your todo.txt file in every text editor ever made, regardless of operating system or vendor.</p>
-					<p>The todo.txt format is <a href="https://github.com/todotxt/todo.txt-cli/wiki/The-Todo.txt-Format">a simple set of rules</a> that make todo.txt both human and machine-readable. The format supports priorities, creation and completion dates, projects and contexts. That's all you need to be productive. <a href="todo.txt">See an example Todo.txt file</a>.</p><br>
+					<p>The todo.txt format is <a href="https://github.com/todotxt/todo.txt">a simple set of rules</a> that make todo.txt both human and machine-readable. The format supports priorities, creation and completion dates, projects and contexts. That's all you need to be productive. <a href="todo.txt">See an example Todo.txt file</a>.</p><br>
 					<span class="hidden-tablet">
 					<h3>What Users Are Saying</h3>
 					<p>


### PR DESCRIPTION
I knew I missed something. Changed the todo.txt format link so it links directly now.

Some other things I noticed (I'm tagging this with #1, but ideally there should be a list of all the things we want to do and a milestone for it):

- The website often changes between `todo.txt` and `Todo.txt`. Which one do we want to use?
- Instead of linking to a todo.txt file, it would be much better IMO if we included an example on the homepage itself (with syntax highlighting!) Why?
    - At the end of the day, it's still a plain text file. You can do whatever you want with it, colors included.
    - Most tools use color coding anyway, so it's a more accurate representation of how you'll actually use your todo.txt file.