### PR TITLE
Update wiki link

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 					<p><a href="https://github.com/todotxt/todo.txt-cli/releases" class="btn-large btn-success" title="Download Todo.txt CLI">Download Todo.txt CLI &raquo;</a></p><br>
 					<p>Find out more:</p>
 					<p><ul>
-						<li><a href="https://wiki.github.com/todotxt/todo.txt-cli">Documentation</a>—everything you need to know about how to use Todo.txt CLI</li>
+						<li><a href="https://github.com/todotxt/todo.txt-cli/wiki/User-Documentation">Documentation</a>—everything you need to know about how to use Todo.txt CLI</li>
 						<li><a href="https://groups.yahoo.com/group/todotxt/">Mailing List</a>—ask the Todo.txt community</li>
 					</ul>
 					</p>


### PR DESCRIPTION
The old wiki.github.com link is no longer valid. Instead, wiki's are now under the repository's wiki tab.