### PR TITLE
Change mailing list to gitter

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 					<p>Find out more:</p>
 					<p><ul>
 						<li><a href="https://github.com/todotxt/todo.txt-cli/wiki/User-Documentation">Documentation</a>—everything you need to know about how to use Todo.txt CLI</li>
-						<li><a href="https://groups.yahoo.com/group/todotxt/">Mailing List</a>—ask the Todo.txt community</li>
+						<li><a href="https://gitter.im/todotxt/Lobby">Gitter</a>—ask the Todo.txt community</li>
 					</ul>
 					</p>
 				</div>
@@ -252,7 +252,7 @@
 					<p>Todo.txt's icon designed by <a href="https://twitter.com/eJohnR">John Rowley</a>.</p>
 					<p>The first version of the Todo.txt CLI script was originally <a href="https://lifehacker.com/software/top/geek-to-live--readerwritten-todotxt-manager-173018.php">published in 2006 on Lifehacker</a>.</p>
 
-					<p>All software comes as is with no warranty.  Do back up your todo.txt before you read another word.  Support is available on the <a href="https://groups.yahoo.com/group/todotxt/">Todo.txt community mailing list</a>.</p>
+					<p>All software comes as is with no warranty.  Do back up your todo.txt before you read another word.  Support is available on the <a href="https://gitter.im/todotxt/Lobby">Todo.txt community chat room</a>.</p>
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
Mailing list looks abandoned and there is a [notice](https://groups.yahoo.com/neo/groups/todotxt/info) from Yahoo:

>Attention: Starting December 14, 2019 Yahoo Groups will no longer host user created content on its sites. New content can no longer be uploaded after October 28, 2019. Sending/Receiving email functionality is not going away, you can continue to communicate via any email client with your group members. 

I suggest directing users to the [Gitter room](https://gitter.im/todotxt/Lobby) instead.