### PR TITLE
Added element#id to community apps > mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
 					<p>Todo.txt syntax highlighter for gedit.</p>
 				</div>
 				<div class="span3">
-					<h3>Mobile</h3>
+					<h3 id="communityMobile">Mobile</h3>
 					
 					<h4><a href="https://monkeystew.org/apps/">Todo.txt Enyo</a></h4>
 					<p>A webOS application for managing your todo.txt file written using the EnyoJS framework, by <a href="https://github.com/thrrgilag">thrrgilag</a>.</p>
@@ -226,7 +226,7 @@
 					<p>Powerful todo.txt app for Android, by <a href="https://mpcjanssen.nl/">Mark Janssen</a>. Also available in a <a href="https://play.google.com/store/apps/details?id=nl.mpcjanssen.simpletask">cloudless</a> version.</p>
 					
 					<h4><a href="https://play.google.com/store/apps/details?id=net.c306.ttsuper&referrer=utm_source%3Dtodotxt_website%26utm_medium%3Dcommunity_apps">Todo.txt for Android</a></h4>
-					<p>Todo.txt for Android - fast, powerful, modern UI, syncs with Dropbox, Google Drive and local files (cloudless).  Supports 6.0 Marshmallow or higher. Offered by <a href="https://c306.net">Aditya Bhaskar</a>.</p>
+					<p>Fast, powerful, modern UI; syncs with Dropbox, Google Drive and local files (cloudless).  Supports 6.0 Marshmallow or higher. Offered by <a href="https://c306.net">Aditya Bhaskar</a>.</p>
 
 					<h4><a href="https://github.com/gsantner/markor">Markor</a></h4>
 					<p>Lightweight Android app - Notes, ToDo &amp; Bookmarks. Supports Markdown &amp; todo.txt, by <a href="https://gsantner.net/?source=todotxt&project=markor">Gregor Santner</a>.</p>


### PR DESCRIPTION
Adde the id so the mobile apps section can be linked directly from external sources, primarily from updated readme in [this PR](https://github.com/todotxt/todo.txt-android/pull/511)