### PR TITLE
Update jdotxt link to point to new version.

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
 					<h4><a href="https://github.com/QTodoTxt/QTodoTxt2/">QTodoTxt2</a></h4>
 					<p>A fast, cross-platform todo.txt GUI written in Python, by Matthieu Nantern.</p>
 
-					<h4><a href="https://github.com/chms/jdotxt">jdotxt</a></h4>
+					<h4><a href="https://github.com/t7ko/jdotxt">jdotxt</a></h4>
 					<p>An open-source, Java-based client for Windows, Mac OS X and Linux, by Christian M. Schmid.</p>
 
 					<h4><a href="https://github.com/onovy/otodo">otodo</a></h4>


### PR DESCRIPTION
        I am now maintaining jdotxt. Old maintainer does not seem to be
        interested in maintaining it further.  Original link:
        https://github.com/chms/jdotxt . Last updated 3 years ago.  It
        does not even allow to download the app any more -- downloads
        were hosted on author's personal home page, which is no longer
        available.

Signed-off-by: Ivan Tishchenko <ivan.t7ko@gmail.com>