### PR TITLE
Add todo-indicator link to "Desktop" section of the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,9 @@
                     <h4><a href="https://github.com/vonshednob/pter">pter</a></h4>
                     <p>A highly configurable TUI (text user interface) for Linux and a GUI for Windows, Mac, and Linux with powerful search capabilities.</p>
 
+					<h4><a href="https://github.com/keithfancher/Todo-Indicator">todo-indicator</a></h4>
+					<p>An Ubuntu app indicator for todo.txt-style lists.</p>
+
 				</div>
 				<div class="span3">
 					<h3>Web</h3>


### PR DESCRIPTION
Add a [todo-indicator](https://github.com/keithfancher/Todo-Indicator) link to the "Desktop" section of the site.

By the way, I noticed some inconsistency with tabs/spaces in `index.html` -- I went with tabs, since *most* of the file seemed to do so as well.

Thanks!