### PR TITLE
Add `todoreport` tool and `todo-txt` library to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,9 @@
                     <h4><a href="https://github.com/vonshednob/pter">pter</a></h4>
                     <p>A highly configurable TUI (text user interface) for Linux and a GUI for Windows, Mac, and Linux with powerful search capabilities.</p>
 
+					<h4><a href="https://sr.ht/~sschwarzer/todo-txt/">todoreport</a></h4>
+					<p>CLI tool that prints an overview from one or more todo.txt files. Use options to control (optionally nested) grouping and sorting.</p>
+
 				</div>
 				<div class="span3">
 					<h3>Web</h3>

--- a/index.html
+++ b/index.html
@@ -254,6 +254,9 @@
                     <h4><a href="https://github.com/vonshednob/pytodotxt">pytodotxt</a></h4>
                     <p>Python abstraction layer to handle todo.txt files.</p>
 
+					<h4><a href="https://pkgs.racket-lang.org/package/todo-txt">todo-txt</a></h4>
+					<p>Racket package to parse, group and sort todo.txt tasks.</p>
+
 				</div>
 			</div>
 			<div class="row">


### PR DESCRIPTION
Add `todoreport` (https://sr.ht/~sschwarzer/todo-txt/) to "desktop apps" and the underlying Racket library `todo-txt` (https://pkgd.racket-lang.org/pkgn/package/todo-txt) to "developer tools"